### PR TITLE
Update plot_pie so bbox_props is function param

### DIFF
--- a/riskfolio/src/PlotFunctions.py
+++ b/riskfolio/src/PlotFunctions.py
@@ -522,7 +522,7 @@ def plot_frontier(
 
 
 def plot_pie(
-    w, title="", others=0.05, nrow=25, cmap="tab20", height=6, width=8, ax=None
+    w, title="", others=0.05, nrow=25, cmap="tab20", height=6, width=8, ax=None, bbox_props=dict(boxstyle="square,pad=0.3", fc="w", ec="k", lw=0.72)
 ):
     r"""
     Create a pie chart with portfolio weights.
@@ -649,7 +649,6 @@ def plot_pie(
 
     ax.legend(wedges, labels, loc="center left", bbox_to_anchor=(1, 0.5), ncol=n)
 
-    bbox_props = dict(boxstyle="square,pad=0.3", fc="w", ec="k", lw=0.72)
     kw = dict(
         xycoords="data",
         textcoords="data",


### PR DESCRIPTION
Would it be possible to add bbox_props as a parameter to the plot_pie function in order to make the chart even more customisable? My issue is that I'm using a dark theme for the Jupyter notebooks and I created a custom matplotlib style by creating a rcParams file. I've been looking on how to change the bbox style from there but without success. Since my text color is white, I need the bbox background to be customisable. Maybe there's a way but I couldn't figure it out. That's why I came here to propose this change.

Probably it could also be applied to some of the other Plot Functions. I'm down to apply the changes if you are interested in it and, also, following the format you require to do so.

Podemos hablar en español si lo deseas también. Un saludo y muchas gracias por la librería.