### PR TITLE
Replace `np.int` with `np.int32` and fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Installation requires:
 - [xlsxwriter](https://xlsxwriter.readthedocs.io) >= 1.3.7
 - [networkx](https://networkx.org) >= 2.5.1
 - [astropy](https://www.astropy.org) >= 4.3.1
-- [pybind11[(https://pybind11.readthedocs.io/en/stable/) >= 2.10.1
+- [pybind11](https://pybind11.readthedocs.io/en/stable/) >= 2.10.1
 
 ## Installation
 

--- a/riskfolio/src/AuxFunctions.py
+++ b/riskfolio/src/AuxFunctions.py
@@ -713,7 +713,7 @@ def ltdi_matrix(X, alpha=0.05):
 
     m = X1.shape[0]
     n = X1.shape[1]
-    k = np.int(np.ceil(m * alpha))
+    k = np.int32(np.ceil(m * alpha))
     mat = np.ones((n, n))
 
     if k > 0:


### PR DESCRIPTION

## Env

- Riskfolio-Lib: 245510c
- Debian 12
- Python 3.11.2

Pure venv with only `Riskfolio-Lib` installed.

```
arch==6.1.0
astropy==5.3
contourpy==1.1.0
cvxpy==1.3.1
cycler==0.11.0
ecos==2.0.12
fonttools==4.40.0
joblib==1.2.0
kiwisolver==1.4.4
matplotlib==3.7.1
networkx==3.1
numpy==1.25.0
osqp==0.6.3
packaging==23.1
pandas==2.0.2
patsy==0.5.3
Pillow==9.5.0
pybind11==2.10.4
pyerfa==2.0.0.3
pyparsing==3.1.0
python-dateutil==2.8.2
pytz==2023.3
PyYAML==6.0
qdldl==0.1.7
Riskfolio-Lib @ file:///path-to/Riskfolio-Lib
scikit-learn==1.2.2
scipy==1.10.1
scs==3.2.3
six==1.16.0
statsmodels==0.14.0
threadpoolctl==3.1.0
tzdata==2023.3
XlsxWriter==3.1.2
```

## Problems

After NumPy 1.20, `np.int` is deprecated and removed, in current master head [`AuxFunctions.py`](https://github.com/dcajasn/Riskfolio-Lib/blob/245510c6904ef210db514d0b188871cf0f0ae764/riskfolio/src/AuxFunctions.py#L716) is still using `k = np.int(np.ceil(m * alpha))`

Traceback of my codes:

```
AttributeError                            Traceback (most recent call last)
Cell In[137], line 21
     19 for codep in codependence:
     20     for cov in covariance:
---> 21         w = port.optimization(model=model,
     22                               codependence=codep,
     23                               rm=rm,
     24                               rf=rf,
     25                               linkage=link,
     26                               covariance=cov,
     27                               leaf_order=leaf_order)
     28         w_s = pd.concat([w_s, w], axis=1)
     29         returns.append(((1 + df_return).prod().to_numpy() * np.squeeze(w.to_numpy())).sum())

File venv-path/site-packages/riskfolio/src/HCPortfolio.py:908, in HCPortfolio.optimization(self, model, codependence, covariance, obj, rm, rf, l, custom_cov, custom_mu, linkage, k, max_k, bins_info, alpha_tail, gs_threshold, leaf_order, d, **kwargs)
    904     self.codep = af.mutual_info_matrix(self.returns, self.bins_info).astype(
    905         float
    906     )
    907 elif codependence in {"tail"}:
--> 908     self.codep = af.ltdi_matrix(self.returns, alpha=self.alpha_tail).astype(
    909         float
    910     )
    911 elif codependence in {"custom_cov"}:
    912     self.codep = af.cov2corr(custom_cov).astype(float)

File venv-path/site-packages/riskfolio/src/AuxFunctions.py:716, in ltdi_matrix(X, alpha)
    714 m = X1.shape[0]
    715 n = X1.shape[1]
--> 716 k = np.int(np.ceil(m * alpha))
    717 mat = np.ones((n, n))
    719 if k > 0:

File venv-path/site-packages/numpy/__init__.py:305, in __getattr__(attr)
    300     warnings.warn(
    301         f"In the future `np.{attr}` will be defined as the "
    302         "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    304 if attr in __former_attrs__:
--> 305     raise AttributeError(__former_attrs__[attr])
    307 # Importing Tester requires importing all of UnitTest which is not a
    308 # cheap import Since it is mainly used in test suits, we lazy import it
    309 # here to save on the order of 10 ms of import time for most users
    310 #
    311 # The previous way Tester was imported also had a side effect of adding
    312 # the full `numpy.testing` namespace
    313 if attr == 'testing':

AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

Actually, you could simply open a console to reproduce:

```python-console
>>> import numpy as np
>>> np.int
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lqhuang/Git/Riskfolio-Lib/.venv/lib/python3.11/site-packages/numpy/__init__.py", line 313, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
```

## What this PR did

1. Replace `np.int` with `np.int32` (I'm not very sure whether it satisfies required precision)
2. Fix a typo error in README

Your review and opinions are appreciated! Thanks!

Sincerely,
Lanqing

