### PR TITLE
Fix: use `elif` for covariance method dispatch to prevent fall-through

### DIFF
--- a/riskfolio/src/ParamsEstimation.py
+++ b/riskfolio/src/ParamsEstimation.py
@@ -214,7 +214,7 @@ def covar_matrix(
 
     if method == "hist":
         cov = np.cov(X, rowvar=False)
-    if method == "semi":
+    elif method == "semi":
         T, N = X.shape
         mu = X.mean().to_numpy().reshape(1, -1)
         a = X - np.repeat(mu, T, axis=0)


### PR DESCRIPTION
I think the if here was supposed to be an elif.