### PR TITLE
Add optional Adanos sentiment views

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -568,6 +568,7 @@ Contents
     Hierarchical Clustering Models <hcportfolio>
     Parameters Estimation <parameters>
     Constraints Functions <constraints>
+    Adanos Sentiment Functions <sentiment>
     Risk Functions <risk>
     Plot Functions <plot>
     Reports <reports>

--- a/docs/source/sentiment.rst
+++ b/docs/source/sentiment.rst
@@ -1,0 +1,36 @@
+###########################
+Adanos Sentiment Functions
+###########################
+
+This module has optional helpers for using Adanos Market Sentiment API data
+with Riskfolio-Lib portfolio workflows. The API covers stock sentiment from
+Reddit, X / FinTwit, News and Polymarket, and can be used to build absolute
+Black Litterman views.
+
+The integration does not add a hard dependency. It uses Python's standard
+library for the request and returns pandas objects that can be passed to the
+existing Riskfolio-Lib estimators and portfolio classes.
+
+Examples
+========
+
+::
+
+    import riskfolio as rp
+
+    assets = ["AAPL", "MSFT", "NVDA"]
+    sentiment = rp.adanos_sentiment(
+        assets,
+        source="news",
+        api_key="your-adanos-api-key",
+    )
+    P, Q = rp.adanos_sentiment_views(sentiment, assets, scale=0.02, threshold=0.1)
+
+    # P and Q can be passed to Portfolio.blacklitterman_stats.
+
+Module Functions
+================
+
+.. automodule:: SentimentFunctions
+   :members:
+   :private-members:

--- a/riskfolio/src/SentimentFunctions.py
+++ b/riskfolio/src/SentimentFunctions.py
@@ -1,0 +1,208 @@
+""""""  #
+
+"""
+Copyright (c) 2020-2026, Dany Cajas
+All rights reserved.
+This work is licensed under BSD 3-Clause "New" or "Revised" License.
+License available at https://github.com/dcajasn/Riskfolio-Lib/blob/master/LICENSE.txt
+"""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "adanos_sentiment",
+    "adanos_sentiment_views",
+]
+
+ADANOS_SOURCES = {"reddit", "x", "news", "polymarket"}
+ADANOS_BASE_URL = "https://api.adanos.org"
+
+
+def adanos_sentiment(
+    tickers,
+    source="reddit",
+    days=7,
+    api_key=None,
+    base_url=ADANOS_BASE_URL,
+    timeout=10,
+):
+    r"""
+    Download Adanos Market Sentiment API data for US stocks.
+
+    Parameters
+    ----------
+    tickers : str or iterable
+        Tickers to query. It can be a comma separated string like
+        ``"AAPL,MSFT"`` or an iterable like ``["AAPL", "MSFT"]``.
+
+    source : str, optional
+        Adanos source. Possible values are ``"reddit"``, ``"x"``,
+        ``"news"`` and ``"polymarket"``. The default is ``"reddit"``.
+
+    days : int, optional
+        Lookback window in days. The default is 7.
+
+    api_key : str, optional
+        Adanos API key. If not provided, ``ADANOS_API_KEY`` environment
+        variable will be used.
+
+    base_url : str, optional
+        Adanos API base URL. The default is ``"https://api.adanos.org"``.
+
+    timeout : int or float, optional
+        Request timeout in seconds. The default is 10.
+
+    Returns
+    -------
+    data : DataFrame
+        Sentiment data indexed by ticker.
+
+    Examples
+    --------
+    ::
+
+        import riskfolio as rp
+
+        sentiment = rp.adanos_sentiment(["AAPL", "MSFT"], source="news")
+
+    """
+
+    source = _normalize_source(source)
+    ticker_list = _normalize_tickers(tickers)
+    api_key = _get_api_key(api_key)
+    params = urllib.parse.urlencode({"tickers": ",".join(ticker_list), "days": days})
+    url = "{}/{}/stocks/v1/compare?{}".format(base_url.rstrip("/"), source, params)
+    request = urllib.request.Request(
+        url,
+        headers={"X-API-Key": api_key, "Accept": "application/json"},
+        method="GET",
+    )
+
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    data = pd.DataFrame(payload.get("stocks", []))
+    if data.empty:
+        return pd.DataFrame(index=pd.Index([], name="ticker"))
+    if "ticker" not in data.columns:
+        raise ValueError("Adanos response must include a ticker field")
+
+    data["ticker"] = data["ticker"].astype(str).str.upper()
+    data = data.set_index("ticker")
+    data.index.name = "ticker"
+    return data
+
+
+def adanos_sentiment_views(
+    sentiment,
+    assets,
+    score="sentiment_score",
+    scale=0.01,
+    threshold=0.0,
+):
+    r"""
+    Build Black Litterman absolute views from Adanos sentiment scores.
+
+    Parameters
+    ----------
+    sentiment : DataFrame
+        Sentiment data indexed by ticker. It can be the output of
+        :func:`adanos_sentiment`.
+
+    assets : list
+        Assets in the same order used by the portfolio returns matrix.
+
+    score : str, optional
+        Column used to build the return views. The default is
+        ``"sentiment_score"``.
+
+    scale : scalar, optional
+        Multiplier applied to the score to convert sentiment units into
+        return views. The default is 0.01.
+
+    threshold : scalar, optional
+        Minimum absolute score required to include a view. The default is 0.
+
+    Returns
+    -------
+    P : nd-array
+        Matrix of shape (n_views, n_assets) that identifies the assets in
+        each view.
+
+    Q : nd-array
+        Expected return vector of shape (n_views, 1) implied by the sentiment
+        views.
+
+    Examples
+    --------
+    ::
+
+        import riskfolio as rp
+
+        sentiment = rp.adanos_sentiment(["AAPL", "MSFT"], source="news")
+        P, Q = rp.adanos_sentiment_views(sentiment, ["AAPL", "MSFT"], scale=0.02)
+
+    """
+
+    if not isinstance(sentiment, pd.DataFrame):
+        raise ValueError("sentiment must be a DataFrame")
+    if score not in sentiment.columns:
+        raise ValueError("sentiment must include the score column")
+
+    assets = _normalize_tickers(assets)
+    sentiment = sentiment.copy()
+    sentiment.index = sentiment.index.astype(str).str.upper()
+    if sentiment.index.has_duplicates:
+        raise ValueError("sentiment index must not contain duplicate tickers")
+
+    P = []
+    Q = []
+    for i, asset in enumerate(assets):
+        if asset not in sentiment.index:
+            continue
+        value = sentiment.loc[asset, score]
+        if pd.isna(value):
+            continue
+        value = float(value)
+        if abs(value) < threshold:
+            continue
+        view = [0.0] * len(assets)
+        view[i] = 1.0
+        P.append(view)
+        Q.append([value * scale])
+
+    if len(P) == 0:
+        return np.empty((0, len(assets))), np.empty((0, 1))
+
+    return np.array(P, ndmin=2, dtype=float), np.array(Q, ndmin=2, dtype=float)
+
+
+def _get_api_key(api_key):
+    api_key = (api_key or os.getenv("ADANOS_API_KEY", "")).strip()
+    if not api_key:
+        raise ValueError("Please provide api_key or set ADANOS_API_KEY")
+    return api_key
+
+
+def _normalize_source(source):
+    source = source.strip().lower()
+    if source not in ADANOS_SOURCES:
+        raise ValueError("source must be one of: reddit, x, news, polymarket")
+    return source
+
+
+def _normalize_tickers(tickers):
+    if tickers is None:
+        raise ValueError("tickers must contain at least one ticker")
+    if isinstance(tickers, str):
+        tickers = tickers.split(",")
+    tickers = [str(ticker).strip().upper() for ticker in tickers if str(ticker).strip()]
+    if not tickers:
+        raise ValueError("tickers must contain at least one ticker")
+    return tickers

--- a/riskfolio/src/__init__.py
+++ b/riskfolio/src/__init__.py
@@ -18,3 +18,4 @@ from .AuxFunctions import *
 from .DBHT import *
 from .OwaWeights import *
 from .GerberStatistic import *
+from .SentimentFunctions import *

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2020-2026 Dany Cajas
+
+import json
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import riskfolio as rp
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_adanos_sentiment_downloads_compare_data():
+    payload = {
+        "stocks": [
+            {"ticker": "AAPL", "sentiment_score": 0.35, "buzz_score": 71.2},
+            {"ticker": "MSFT", "sentiment_score": -0.2, "buzz_score": 42.5},
+        ]
+    }
+
+    with patch("urllib.request.urlopen", return_value=_Response(payload)) as urlopen:
+        data = rp.adanos_sentiment(
+            "aapl, msft",
+            source="News",
+            days=3,
+            api_key="test-key",
+            base_url="https://api.adanos.org/",
+            timeout=5,
+        )
+
+    request = urlopen.call_args.args[0]
+    assert request.full_url == (
+        "https://api.adanos.org/news/stocks/v1/compare?tickers=AAPL%2CMSFT&days=3"
+    )
+    assert request.headers["X-api-key"] == "test-key"
+    assert request.headers["Accept"] == "application/json"
+    assert urlopen.call_args.kwargs["timeout"] == 5
+    assert list(data.index) == ["AAPL", "MSFT"]
+    assert data.loc["AAPL", "sentiment_score"] == 0.35
+
+
+def test_adanos_sentiment_uses_environment_api_key(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "env-key")
+
+    with patch("urllib.request.urlopen", return_value=_Response({"stocks": []})) as urlopen:
+        data = rp.adanos_sentiment(["AAPL"], api_key="")
+
+    request = urlopen.call_args.args[0]
+    assert request.headers["X-api-key"] == "env-key"
+    assert data.empty
+    assert data.index.name == "ticker"
+
+
+def test_adanos_sentiment_validates_inputs(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="tickers must contain"):
+        rp.adanos_sentiment([])
+
+    with pytest.raises(ValueError, match="tickers must contain"):
+        rp.adanos_sentiment(None)
+
+    with pytest.raises(ValueError, match="source must be one of"):
+        rp.adanos_sentiment(["AAPL"], source="invalid", api_key="test-key")
+
+    with pytest.raises(ValueError, match="Please provide api_key"):
+        rp.adanos_sentiment(["AAPL"], api_key="")
+
+
+def test_adanos_sentiment_views_builds_black_litterman_views():
+    sentiment = pd.DataFrame(
+        {
+            "sentiment_score": [0.5, -0.25, 0.0],
+            "buzz_score": [70.0, 55.0, 10.0],
+        },
+        index=["AAPL", "MSFT", "TSLA"],
+    )
+
+    P, Q = rp.adanos_sentiment_views(
+        sentiment,
+        ["MSFT", "AAPL", "NVDA"],
+        scale=0.02,
+        threshold=0.1,
+    )
+
+    np.testing.assert_array_equal(P, np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]))
+    np.testing.assert_array_almost_equal(Q, np.array([[-0.005], [0.01]]))
+
+
+def test_adanos_sentiment_views_validates_data():
+    with pytest.raises(ValueError, match="sentiment must be a DataFrame"):
+        rp.adanos_sentiment_views([], ["AAPL"])
+
+    with pytest.raises(ValueError, match="score column"):
+        rp.adanos_sentiment_views(pd.DataFrame(index=["AAPL"]), ["AAPL"])
+
+    sentiment = pd.DataFrame({"sentiment_score": [0.2, 0.3]}, index=["AAPL", "AAPL"])
+    with pytest.raises(ValueError, match="duplicate tickers"):
+        rp.adanos_sentiment_views(sentiment, ["AAPL"])
+
+
+def test_adanos_sentiment_views_returns_empty_view_matrices():
+    sentiment = pd.DataFrame({"sentiment_score": [0.05]}, index=["AAPL"])
+
+    P, Q = rp.adanos_sentiment_views(sentiment, ["AAPL", "MSFT"], threshold=0.1)
+
+    assert P.shape == (0, 2)
+    assert Q.shape == (0, 1)


### PR DESCRIPTION
## Summary
- add optional Adanos Market Sentiment API helper returning ticker-indexed sentiment DataFrames
- add `adanos_sentiment_views` to convert sentiment scores into Black-Litterman absolute view matrices
- document the optional workflow and add mocked network tests

## Notes
- no new hard dependency; the API call uses Python stdlib `urllib`
- API keys can be passed directly or via `ADANOS_API_KEY`

## Validation
- `.venv/bin/python -m pytest tests/test_sentiment.py -q`
- `python3 -m py_compile riskfolio/src/SentimentFunctions.py tests/test_sentiment.py`
- `git diff --check`