### PR TITLE
Add FXMacroData portfolio optimization tutorial

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,3 +60,4 @@
 - Mean Even Semi Moment of Order 2p Optimization [Tutorial 56](https://github.com/dcajasn/Riskfolio-Lib/blob/master/examples/Tutorial%2056%20-%20Mean%20Even%20Semi%20Moment%20of%20Order%202p%20Optimization.ipynb)
 - Mean Risk Optimization using Entropy Pooling [Tutorial 57](https://github.com/dcajasn/Riskfolio-Lib/blob/master/examples/Tutorial%2057%20-%20Mean%20Risk%20Optimization%20using%20Entropy%20Pooling.ipynb)
 - Mean Variance Skewness Kurtosis Optimization [Tutorial 58](https://github.com/dcajasn/Riskfolio-Lib/blob/master/examples/Tutorial%2058%20-%20Mean%20Variance%20Skewness%20Kurtosis%20Optimization.ipynb)
+- FX Portfolio Optimization with FXMacroData [Tutorial 59](https://github.com/dcajasn/Riskfolio-Lib/blob/master/examples/Tutorial%2059%20-%20FX%20Portfolio%20Optimization%20with%20FXMacroData.ipynb)

--- a/examples/Tutorial 59 - FX Portfolio Optimization with FXMacroData.ipynb
+++ b/examples/Tutorial 59 - FX Portfolio Optimization with FXMacroData.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FX Portfolio Optimization with FXMacroData\n",
+    "\n",
+    "This tutorial uses the official `fxmacrodata` Python client to fetch daily FX reference-rate history, converts the price series into aligned returns, and then optimizes a long-only FX portfolio with Riskfolio-Lib.\n",
+    "\n",
+    "The client reads `FXMACRODATA_API_KEY` or `FXMD_API_KEY` from the environment. The chosen pairs require a key for full history; never paste a key into this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pip install riskfolio-lib fxmacrodata pandas\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "import pandas as pd\n",
+    "import riskfolio as rp\n",
+    "from fxmacrodata import FXMacroDataClient\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_fx_prices(\n",
+    "    client: FXMacroDataClient,\n",
+    "    pairs: dict[str, tuple[str, str]],\n",
+    "    start_date: str,\n",
+    "    end_date: str,\n",
+    ") -> pd.DataFrame:\n",
+    "    columns = []\n",
+    "    for asset, (base, quote) in pairs.items():\n",
+    "        rows = client.forex(base, quote, start_date=start_date, end_date=end_date)\n",
+    "        frame = pd.DataFrame(rows)\n",
+    "        if not {\"date\", \"val\"}.issubset(frame.columns):\n",
+    "            raise RuntimeError(f\"{asset} response did not contain date and val fields\")\n",
+    "        series = pd.Series(\n",
+    "            pd.to_numeric(frame[\"val\"], errors=\"coerce\").to_numpy(),\n",
+    "            index=pd.to_datetime(frame[\"date\"], utc=True),\n",
+    "            name=asset,\n",
+    "        )\n",
+    "        columns.append(series.groupby(level=0).last())\n",
+    "\n",
+    "    prices = pd.concat(columns, axis=1).sort_index().ffill().dropna()\n",
+    "    if prices.shape[1] < 2 or len(prices) < 2:\n",
+    "        raise RuntimeError(\"at least two aligned FX price series are required\")\n",
+    "    return prices\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key = os.environ.get(\"FXMACRODATA_API_KEY\") or os.environ.get(\"FXMD_API_KEY\")\n",
+    "if not api_key:\n",
+    "    raise RuntimeError(\"Set FXMACRODATA_API_KEY or FXMD_API_KEY before requesting protected FX history\")\n",
+    "\n",
+    "client = FXMacroDataClient(api_key=api_key, auth_mode=\"query\")\n",
+    "pairs = {\n",
+    "    \"EURUSD\": (\"EUR\", \"USD\"),\n",
+    "    \"GBPUSD\": (\"GBP\", \"USD\"),\n",
+    "    \"AUDUSD\": (\"AUD\", \"USD\"),\n",
+    "    \"NZDUSD\": (\"NZD\", \"USD\"),\n",
+    "}\n",
+    "prices = fetch_fx_prices(client, pairs, start_date=\"2023-01-01\", end_date=\"2025-12-31\")\n",
+    "returns = prices.pct_change().dropna()\n",
+    "returns.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "portfolio = rp.Portfolio(returns=returns)\n",
+    "portfolio.assets_stats(method_mu=\"hist\", method_cov=\"hist\")\n",
+    "\n",
+    "weights = portfolio.optimization(\n",
+    "    model=\"Classic\",\n",
+    "    rm=\"MV\",\n",
+    "    obj=\"Sharpe\",\n",
+    "    rf=0,\n",
+    "    l=0,\n",
+    "    hist=True,\n",
+    ")\n",
+    "weights.T\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- FXMacroData reference rates are daily official-source values, not executable quotes.\n",
+    "- This example optimizes historical returns; it does not place orders or make portfolio recommendations.\n",
+    "- For release-aware research, join FXMacroData announcement rows by their `announcement_datetime` and ensure no value is used before its release time."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Add a Riskfolio-Lib tutorial that builds aligned daily FX return series and runs a long-only portfolio optimization.
- Use the published `fxmacrodata.Client` and `get_fx_price()` API, including the response `data` envelope.
- Read the FXMacroData API key only from `FXMACRODATA_API_KEY` or `FXMD_API_KEY`; the notebook contains no credential value.
- Add the tutorial to the existing examples index.

## Integration scope

This is a consumer tutorial, not a reusable API client. It uses the one FXMacroData capability needed by the native Riskfolio workflow: protected daily FX history. Other endpoint families are intentionally not wrapped. The notes identify daily reference rates as non-executable and call out release-time handling for readers who later join macro announcements.

## Validation

- Notebook JSON parsed successfully.
- All four code cells compiled successfully on Python 3.12.
- The price-alignment helper passed a mocked two-pair test.
- A protected live smoke test returned and aligned seven EUR/USD and GBP/USD daily rows for 2025-01-02 through 2025-01-10.
- `git diff --check` passed.
- Added content was scanned for high-confidence secrets, environment files, local paths, and internal hosts; no findings.

## Disclosure

I am FXMacroData's owner.
